### PR TITLE
Define the defaults only if they are not defined already

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [MinHook](https://github.com/TsudaKageyu/minhook) (For kiero::bind function)
 
 ### Example
-To start, go to the kiero.h and select the desired hooks
+To start, select the desired hooks and then proceed to the main work
 ```C++
 // Example for D3D9 hook
 #define KIERO_INCLUDE_D3D9   1 // 1 if you need D3D9 hook
@@ -29,11 +29,6 @@ To start, go to the kiero.h and select the desired hooks
 #define KIERO_INCLUDE_D3D12  0 // 1 if you need D3D12 hook
 #define KIERO_INCLUDE_OPENGL 0 // 1 if you need OpenGL hook
 #define KIERO_INCLUDE_VULKAN 0 // 1 if you need Vulkan hook
-```
-
-Then proceed to the main work
-```C++
-// Example for D3D9 hook
 
 // Include required libraries
 #include "kiero.h"

--- a/kiero.h
+++ b/kiero.h
@@ -5,13 +5,33 @@
 
 #define KIERO_VERSION "1.2.6"
 
+#ifndef KIERO_INCLUDE_D3D9
 #define KIERO_INCLUDE_D3D9   0 // 1 if you need D3D9 hook
+#endif
+
+#ifndef KIERO_INCLUDE_D3D10
 #define KIERO_INCLUDE_D3D10  0 // 1 if you need D3D10 hook
+#endif
+
+#ifndef KIERO_INCLUDE_D3D11
 #define KIERO_INCLUDE_D3D11  0 // 1 if you need D3D11 hook
+#endif
+
+#ifndef KIERO_INCLUDE_D3D12
 #define KIERO_INCLUDE_D3D12  0 // 1 if you need D3D12 hook
+#endif
+
+#ifndef KIERO_INCLUDE_OPENGL
 #define KIERO_INCLUDE_OPENGL 0 // 1 if you need OpenGL hook
+#endif
+
+#ifndef KIERO_INCLUDE_VULKAN
 #define KIERO_INCLUDE_VULKAN 0 // 1 if you need Vulkan hook
+#endif
+
+#ifndef KIERO_USE_MINHOOK
 #define KIERO_USE_MINHOOK    0 // 1 if you will use kiero::bind function
+#endif
 
 #define KIERO_ARCH_X64 0
 #define KIERO_ARCH_X86 0


### PR DESCRIPTION
This PR modifies the Header File to only define the default values for the hooks, if they are not defined already. I have also updated the README accordingly to the changes.

This allows you to define the needed hooks before including the Header file, and without modifying the Header file itself (i.e. not causing git changes, so you can include it as a submodule cleanly).