### PR TITLE
Wrap D3D11CreateDeviceAndSwapChain's GetProcAddress with a "void*" typecast

### DIFF
--- a/kiero.cpp
+++ b/kiero.cpp
@@ -269,7 +269,7 @@ kiero::Status::Enum kiero::init(RenderType::Enum _renderType)
 				}
 
 				void* D3D11CreateDeviceAndSwapChain;
-				if ((D3D11CreateDeviceAndSwapChain = ::GetProcAddress(libD3D11, "D3D11CreateDeviceAndSwapChain")) == NULL)
+				if ((D3D11CreateDeviceAndSwapChain = (void*)::GetProcAddress(libD3D11, "D3D11CreateDeviceAndSwapChain")) == NULL)
 				{
 					::DestroyWindow(window);
 					::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);


### PR DESCRIPTION
This seemingly fixed my problem when attempting to compile with MinGW where it will complain about an "invalid conversion from 'FARPROC' {aka 'long long int (*)()'} to 'void*' [-fpermissive]".